### PR TITLE
Handle the routes called by the inv script

### DIFF
--- a/foreman_stub.py
+++ b/foreman_stub.py
@@ -45,6 +45,7 @@ def get_page_num():
 
 @app.route('/api/v2/hosts')
 @app.route('/api/v2/hosts/<hostid>')
+@app.route('/api/v2/hosts/<hostid>/facts')
 def get_hosts(hostid=None):
     """Render fixture contents from cache."""
     pagenum = get_page_num()
@@ -54,7 +55,10 @@ def get_hosts(hostid=None):
         cache_key = f'{cache_key}/{hostid}'
 
     try:
-        resp = PAGECACHE[cache_key][pagenum]
+        if request.path.endswith('/facts'):
+            resp = PAGECACHE[cache_key]
+        else:
+            resp = PAGECACHE[cache_key][pagenum]
     except KeyError:
         if DEBUG:
             import q; q/cache_key; q/pagenum; q/hostid

--- a/foreman_stub.py
+++ b/foreman_stub.py
@@ -54,8 +54,8 @@ def get_hosts(hostid=None):
     if hostid is not None:
         cache_key = f'{cache_key}/{hostid}'
 
+    resp = PAGECACHE[cache_key]
     try:
-        resp = PAGECACHE[cache_key]
         if not request.path.endswith('/facts'):
             resp = resp[pagenum]
     except KeyError:

--- a/foreman_stub.py
+++ b/foreman_stub.py
@@ -55,10 +55,9 @@ def get_hosts(hostid=None):
         cache_key = f'{cache_key}/{hostid}'
 
     try:
-        if request.path.endswith('/facts'):
-            resp = PAGECACHE[cache_key]
-        else:
-            resp = PAGECACHE[cache_key][pagenum]
+        resp = PAGECACHE[cache_key]
+        if not request.path.endswith('/facts'):
+            resp = resp[pagenum]
     except KeyError:
         if DEBUG:
             import q; q/cache_key; q/pagenum; q/hostid


### PR DESCRIPTION
The inventory script (not plugin) calls a hosts/<number>/facts route which wasn't handled properly.